### PR TITLE
Mask temporary access token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,7 @@ runs:
       env:
         DROPBOX_ACCESS_TOKEN: ${{ env.DROPBOX_ACCESS_TOKEN }}      
       run: |
+        echo "::add-mask::$DROPBOX_ACCESS_TOKEN"
         curl -X POST https://content.dropboxapi.com/2/files/upload \
           --header "Authorization: Bearer $DROPBOX_ACCESS_TOKEN" \
           --header "Dropbox-API-Arg: {\"path\":\"${{ inputs.target-path }}\"}" \


### PR DESCRIPTION
We need to mask the temporary access token from the output according to the [`add-mask`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-masking-a-generated-output-within-a-single-job) directive.

See: https://github.com/Lewuathe/dropbox-github-action/issues/4